### PR TITLE
Proposal: Effect result module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@
 !manifest.toml
 !src
 !src/*.gleam
+!src/effect_result
+!src/effect_result/*.gleam
 !test
 !test/*.gleam

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gleam add effect@1.2.0
 ```
 
 This library includes an implementation of `Effect` that handles results differently.
-See [effect_result](effect_result/README.md) for details.
+See [effect_result](src/effect_result/README.md) for details.
 
 ```gleam
 import effect

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/effect/)
 
 ```sh
-gleam add effect@1.1.0
+gleam add effect@1.2.0
 ```
+
+This library includes an implementation of `Effect` that handles results differently.
+See [effect_result](effect_result/README.md) for details.
+
 ```gleam
 import effect
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "effect"
-version = "1.1.0"
+version = "1.2.0"
 
 target = "javascript"
 

--- a/src/effect_result/README.md
+++ b/src/effect_result/README.md
@@ -13,7 +13,6 @@ The motivation was to create an API for dealing with promises from [gleam_promis
    - [Basic Construction](#basic-construction)  
    - [Chaining Effects](#chaining-effects)  
    - [Handling Promises](#handling-promises)  
-   - [Performing the Effect](#performing-the-effect)  
 
 ## Overview
 
@@ -124,11 +123,3 @@ fn main() {
 ```
 
 If you need to map the error type *before* continuing, use `try_await_map_error`.
-
-### Performing the Effect
-
-**Remember**: constructing an effect is purely declarative. It doesn’t do anything until you call `perform(effect, callback)`. This function:
-
-1. Builds an internal `Actions(a, e)` record with `dispatch = callback`.
-2. Iterates over the list of effect steps, passing each one the `Actions`.
-g. Each step calls `dispatch` with `Ok(...)` or `Error(...)`.

--- a/src/effect_result/README.md
+++ b/src/effect_result/README.md
@@ -1,0 +1,132 @@
+A lightweight library for modeling asynchronous effects and error handling in Gleam, inspired by [effect-ts](https://github.com/Effect-TS/core). 
+
+This library allows you to treat asynchronous operations and potential failures as **first-class effectful computations**, which can be composed in a purely functional style before finally being executed.
+
+The motivation was to create an API for dealing with promises from [gleam_promises](https://hexdocs.pm/gleam_javascript/gleam/javascript/promise.html) without having to "color" functions.
+
+## Table of Contents
+
+1. [Overview](#overview)  
+2. [Usage](#usage)  
+   - [Basic Construction](#basic-construction)  
+   - [Chaining Effects](#chaining-effects)  
+   - [Handling Promises](#handling-promises)  
+   - [Performing the Effect](#performing-the-effect)  
+
+## Overview
+
+- **Asynchronous & Error-Encoded**: Each `Effect(a, e)` can produce either an `Ok(a)` (success) or an `Error(e)` (failure).  
+- **Composable**: Build up complex workflows using `map`, `map_error`, and `try`.  
+- **Lifts Promises**: Bridge JavaScript `promise.Promise(Result(a, e))` into the Gleam effect world with `from_promise`, `try_await`, and `try_await_map_error`.  
+- **Perform**: Nothing executes until you call `perform(effect, callback)`. This separates definition from execution.
+
+## Usage
+
+Below are common usage scenarios demonstrating how to create and compose effects, handle failures, work with promises, and finally execute the effect.
+
+### Basic Construction
+
+```gleam
+import effect/effect_result as effect
+import gleam/io
+
+pub fn main() {
+  // Construct an effect from a plain Result:
+  let eff_from_result = effect.from_result(Ok("Hello"))
+
+  // Succeed / Fail shortcuts:
+  let eff_ok = effect.succeed(42)
+  let eff_err = effect.fail("Oops!")
+
+  // Perform them:
+  effect.perform(eff_from_result, fn(res) {
+    case res {
+      Ok(str) -> io.println("Got: " <> str)
+      Error(err) -> io.println("Error: " <> err)
+    }
+  })
+}
+```
+
+### Chaining Effects
+
+Use `try` to sequence operations, only continuing on success, or short-circuiting on error:
+
+```gleam
+import effect/effect_result as effect
+import gleam/io
+
+type TooSmallError {
+  TooSmallError
+}
+
+pub fn main() {
+  let computation =
+    effect.succeed(10)
+    // successful effect
+    |> effect.try(fn(x: Int) {
+      // 
+      case x < 5 {
+        True -> effect.fail(TooSmallError)
+        False -> effect.succeed(x * 2)
+      }
+    })
+    |> effect.map(fn(double: Int) { double + 1 })
+
+  effect.perform(computation, fn(res: Result(Int, TooSmallError)) {
+    case res {
+      // prints 21 if x=10
+      Ok(n) -> io.println("Final result: " <> int.to_string(n))
+      // TooSmallError
+      Error(_err) -> io.println("Error: " <> "Too small!")
+    }
+  })
+}
+```
+
+### Handling Promises
+
+You can convert a `promise.Promise(Result(a, e))` into an `Effect(a, e)` using `from_promise`. Then compose it with `try_await` to sequence a follow-up effect:
+
+```gleam
+type FetchError {
+  FetchError(String)
+}
+
+
+fn fetch_data() -> promise.Promise(Result(String, FetchError)) {
+  // For example, some JavaScript network call
+  promise.new(fn(resolve) {
+    // resolve(Ok("Server data"))
+    resolve(Error(FetchError("Network error")))
+  })
+}
+
+fn main() {
+  // `try_await` waits for Ok(a), then calls `f(a) -> Effect(b, e)`
+  let eff =
+    effect.try_await(fetch_data(), fn(data) {
+      // do something with the data
+      effect.from_result(Ok("Got data: " <> data))
+    })
+
+  effect.perform(eff, fn(res) {
+    case res {
+      // Server Data
+      Ok(msg) -> io.println(msg)
+      // Network Error
+      Error(FetchError(msg)) -> io.println("Failed: " <> msg)
+    }
+  })
+}
+```
+
+If you need to map the error type *before* continuing, use `try_await_map_error`.
+
+### Performing the Effect
+
+**Remember**: constructing an effect is purely declarative. It doesn’t do anything until you call `perform(effect, callback)`. This function:
+
+1. Builds an internal `Actions(a, e)` record with `dispatch = callback`.
+2. Iterates over the list of effect steps, passing each one the `Actions`.
+3. Each step calls `dispatch` with `Ok(...)` or `Error(...)`.

--- a/src/effect_result/README.md
+++ b/src/effect_result/README.md
@@ -1,3 +1,5 @@
+# Effect - With Result
+
 A lightweight library for modeling asynchronous effects and error handling in Gleam, inspired by [effect-ts](https://github.com/Effect-TS/core). 
 
 This library allows you to treat asynchronous operations and potential failures as **first-class effectful computations**, which can be composed in a purely functional style before finally being executed.
@@ -129,4 +131,4 @@ If you need to map the error type *before* continuing, use `try_await_map_error`
 
 1. Builds an internal `Actions(a, e)` record with `dispatch = callback`.
 2. Iterates over the list of effect steps, passing each one the `Actions`.
-3. Each step calls `dispatch` with `Ok(...)` or `Error(...)`.
+g. Each step calls `dispatch` with `Ok(...)` or `Error(...)`.

--- a/src/effect_result/effect_result.gleam
+++ b/src/effect_result/effect_result.gleam
@@ -1,0 +1,192 @@
+import gleam/javascript/promise
+import gleam/list
+import gleam/option
+
+/// An effect that can produce either an Ok(a) or an Error(e).
+/// Use `perform` to execute an Effect, providing a callback that
+/// receives the final Result(a, e).
+pub opaque type Effect(a, e) {
+  Effect(run: List(fn(Actions(a, e)) -> Nil))
+}
+
+/// Holds the `dispatch` function used internally by each effect step.
+/// Typically you won't create `Actions` directly; it's used by `perform`.
+pub type Actions(a, e) {
+  Actions(dispatch: fn(Result(a, e)) -> Nil)
+}
+
+/// Create an Effect from a callback that manually dispatches Ok or Error.
+/// Example:
+/// ```gleam
+/// from(fn(dispatch) {
+///   dispatch(Ok(42))
+/// })
+/// ```
+pub fn from(effect: fn(fn(Result(a, e)) -> Nil) -> Nil) -> Effect(a, e) {
+  Effect(run: [fn(actions: Actions(a, e)) { effect(actions.dispatch) }])
+}
+
+/// Create an Effect that immediately dispatches a pre-existing Result(a, e).
+/// Useful for wrapping a plain result in the effect system.
+pub fn from_result(result: Result(a, e)) -> Effect(a, e) {
+  Effect(run: [fn(actions: Actions(a, e)) { actions.dispatch(result) }])
+}
+
+/// Create an Effect from an option, mapping the None case into the error channel
+/// Useful for wrapping an option into the effect system when None is considered an error.
+pub fn from_option(opt: option.Option(a), if_none: e) -> Effect(a, e) {
+  case opt {
+    option.Some(x) -> succeed(x)
+    option.None -> fail(if_none)
+  }
+}
+
+/// Create an Effect that immediately succeeds with value `x`.
+/// Shorthand for `from_result(Ok(x))`.
+pub fn succeed(x: a) -> Effect(a, e) {
+  from(fn(dispatch) { dispatch(Ok(x)) })
+}
+
+/// Create an Effect that immediately fails with error `err`.
+/// Shorthand for `from_result(Error(err))`.
+pub fn fail(err: e) -> Effect(a, e) {
+  from(fn(dispatch) { dispatch(Error(err)) })
+}
+
+/// Transform the success value in an Effect from type `a` to `b`.
+/// The error type `e` is left unchanged.
+/// Example:
+/// ```gleam
+/// succeed(2)
+/// |> map(fn(x) { x * 2 })  // Ok(4)
+/// ```
+pub fn map(effect: Effect(a, e), f: fn(a) -> b) -> Effect(b, e) {
+  Effect(
+    run: list.map(effect.run, fn(eff) {
+      fn(actions: Actions(b, e)) {
+        // Internal adaptation
+        let adapted_actions =
+          Actions(dispatch: fn(result: Result(a, e)) {
+            case result {
+              Ok(value) -> actions.dispatch(Ok(f(value)))
+              Error(err) -> actions.dispatch(Error(err))
+            }
+          })
+        eff(adapted_actions)
+      }
+    }),
+  )
+}
+
+/// Transform the error value in an Effect from type `e` to `e2`.
+/// The success value `a` is left unchanged.
+/// Example:
+/// ```gleam
+/// fail("Oops!")
+/// |> map_error(fn(e) { "Mapped: " <> e })
+/// ```
+pub fn map_error(effect: Effect(a, e), f: fn(e) -> e2) -> Effect(a, e2) {
+  Effect(
+    run: list.map(effect.run, fn(eff) {
+      fn(actions: Actions(a, e2)) {
+        // Internal adaptation
+        let adapted_actions =
+          Actions(dispatch: fn(result: Result(a, e)) {
+            case result {
+              Ok(value) -> actions.dispatch(Ok(value))
+              Error(err) -> actions.dispatch(Error(f(err)))
+            }
+          })
+        eff(adapted_actions)
+      }
+    }),
+  )
+}
+
+/// Chain two Effects. If `effect` succeeds with Ok(a), call `f(a)` to
+/// produce a new Effect(b, e). If `effect` fails, propagate the error.
+/// Example:
+/// ```gleam
+/// succeed(2)
+/// |> try(fn(x) {
+///   if x > 0 { succeed(x * 10) }
+///   else { fail("Can't multiply") }
+/// })
+/// ```
+pub fn try(effect: Effect(a, e), f: fn(a) -> Effect(b, e)) -> Effect(b, e) {
+  Effect(
+    run: list.map(effect.run, fn(eff) {
+      fn(actions: Actions(b, e)) {
+        // Internal adaptation
+        let adapted_actions =
+          Actions(dispatch: fn(result: Result(a, e)) {
+            case result {
+              Ok(value) -> {
+                let Effect(run: runs_b) = f(value)
+                list.each(runs_b, fn(run_b) { run_b(actions) })
+              }
+              Error(err) -> actions.dispatch(Error(err))
+            }
+          })
+        eff(adapted_actions)
+      }
+    }),
+  )
+}
+
+/// Convert a JavaScript Promise<Result(a, e)> into an Effect(a, e).
+/// The Effect will dispatch either Ok(a) or Error(e) based on the
+/// resolved promise value.
+pub fn from_promise(pres: promise.Promise(Result(a, e))) -> Effect(a, e) {
+  Effect(run: [
+    fn(actions: Actions(a, e)) {
+      promise.map(pres, fn(res) {
+        actions.dispatch(res)
+        Nil
+      })
+      Nil
+    },
+  ])
+}
+
+/// Wait on `pres` (a Promise<Result(a, e)>) and then,
+/// if it succeeds with Ok(a), run `f(a)`.
+/// Otherwise, dispatch Error(e).
+pub fn try_await(
+  pres: promise.Promise(Result(a, e)),
+  f: fn(a) -> Effect(b, e),
+) -> Effect(b, e) {
+  from_promise(pres)
+  |> try(f)
+}
+
+/// Like `try_await`, but first map the error using `f_err`.
+/// If the promise fails with Error(e), transform it into Error(e2),
+/// then call `f` if successful.
+pub fn try_await_map_error(
+  pres: promise.Promise(Result(a, e)),
+  f_err: fn(e) -> e2,
+  f: fn(a) -> Effect(b, e2),
+) -> Effect(b, e2) {
+  from_promise(pres)
+  |> map_error(f_err)
+  |> try(f)
+}
+
+/// Execute an Effect by supplying the final callback to handle
+/// the Result(a, e). Use this to “run” the effect.
+/// Example:
+/// ```gleam
+/// let eff = succeed(10)
+/// perform(eff, fn(res) {
+///   case res {
+///     Ok(value) -> io.println("Got: \(value)")
+///     Error(e)  -> io.println("Error: \(e)")
+///   }
+/// })
+/// ```
+pub fn perform(effect: Effect(a, e), callback: fn(Result(a, e)) -> Nil) -> Nil {
+  let actions = Actions(dispatch: callback)
+  list.each(effect.run, fn(run) { run(actions) })
+}
+


### PR DESCRIPTION
adds a module effect_result.

Effect in this implementation is designed to model errors like Result, unifying the API into one type. 

This allows flattening of results and effects during use without having to think about which is which.