### PR TITLE
fix: remove replace error from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ fn main() {
       prom,
       // map the error
       Fetch,
-      // or replace: effect.replace_error(TextRead), or keep: effect.keep_error 
     )
 
     // return just the body

--- a/examples/examples.gleam
+++ b/examples/examples.gleam
@@ -127,9 +127,7 @@ pub fn promises_readme() {
     use text: Response(String) <- effect_promise.from_promise_result(
       prom,
       // map the error
-      effect.replace_error(TextRead),
-      // Fetch,
-    // replace: effect.replace_error(TextRead), keep: effect.keep_error 
+      fn(_) { TextRead },
     )
 
     // return just the body

--- a/src/effect/promise.gleam
+++ b/src/effect/promise.gleam
@@ -9,7 +9,7 @@ import effect
 /// value of the result through the handler.
 /// ```gleam
 /// let promise: Promise(Result(ok, err))
-/// use ok: ok <- from_promise_result(promise, effect.keep_error) // or map the error here
+/// use ok: ok <- from_promise_result(promise, fn (previous_error) { new_error }) // map the error here
 /// effect.succeed(ok) // Effect(ok, err)
 /// ```
 pub fn from_promise_result(


### PR DESCRIPTION
Finally got around to it...

Remove a `effect.replace_error` in the examples that we removed during the last patch.