### PR TITLE
fix: move gleam/promise from dev deps to deps

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,9 +9,9 @@ licences = ["MIT"]
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_javascript = ">= 0.13.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 gleam_fetch = ">= 1.1.0 and < 2.0.0"
 gleam_http = ">= 3.7.2 and < 4.0.0"
-gleam_javascript = ">= 0.13.0 and < 1.0.0"


### PR DESCRIPTION
I'm pretty sure this needs to be a full dep instead of a dev dep since we use it in the effect/promise functions now, whereas before we used the promise package in tests only.